### PR TITLE
test: refactor and stabilize E2E critical-paths tests

### DIFF
--- a/.github/prompts/commit-message.prompt.md
+++ b/.github/prompts/commit-message.prompt.md
@@ -1,0 +1,10 @@
+---
+agent: Documentation Architect
+model: Raptor mini (Preview) (copilot)
+description: Produce Conventional Commit–compliant commit messages using the repository's standards.
+---
+
+- Adhere to the **Commit Message Standards** in `CONTRIBUTING.md` — it is the single source of truth for commit format and conventions.
+
+- When composing the commit message, use the output of `git diff --staged` as the authoritative source.
+

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -53,7 +53,19 @@ jobs:
 
       # Cache for pnpm is handled by setup-node (cache: pnpm), so no extra actions/cache needed.
 
+      - name: Restore node_modules cache
+        id: node-mod-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            .pnpm-store
+          key: ${{ runner.os }}-pnpm-node-modules-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-node-modules-
+
       - name: Install dependencies
+        if: steps.node-mod-cache.outputs.cache-hit != 'true'
         run: pnpm install --no-frozen-lockfile
 
       # --- VALIDATION PHASE ---

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -69,29 +69,28 @@ jobs:
       # On cache hit this avoids running `pnpm install`; on cache miss
       # the subsequent steps will run `pnpm install` and populate the cache
       # for future workflow runs.
-      - name: Restore node_modules and .pnpm-store cache
-        id: cache-node-modules-pnpm
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            .pnpm-store
-          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-
+      # - name: Restore node_modules and .pnpm-store cache
+      #   id: cache-node-modules-pnpm
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: |
+      #       node_modules
+      #       .pnpm-store
+      #     key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-
 
       - name: Install dependencies
-        if: steps.cache-node-modules-pnpm.outputs.cache-hit != 'true'
+        # if: steps.cache-node-modules-pnpm.outputs.cache-hit != 'true'
         run: pnpm install --no-frozen-lockfile
 
-      - name: Save node_modules and .pnpm-store cache
-        uses: actions/cache/save@v4
-        if: steps.cache-node-modules-pnpm.outputs.cache-hit != 'true'
-        with:
-          path: |
-            node_modules
-            .pnpm-store
-          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+      # - name: Save node_modules and .pnpm-store cache
+      #   uses: actions/cache/save@v4
+      #   with:
+      #     path: |
+      #       node_modules
+      #       .pnpm-store
+      #     key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
 
       # --- VALIDATION PHASE ---
 
@@ -109,14 +108,14 @@ jobs:
       # Uses the lockfile/hash to invalidate when dependencies (or Playwright)
       # change. On cache hit the install step is skipped.
       # Project-scoped to .playwright/browsers for consistency with node_modules.
-      - name: Restore Playwright browsers cache
-        id: cache-playwright-browsers
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-
+      # - name: Restore Playwright browsers cache
+      #   id: cache-playwright-browsers
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+      #     key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-
 
       - name: Install Playwright browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
@@ -124,12 +123,12 @@ jobs:
         env:
           PLAYWRIGHT_BROWSERS_PATH: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
-      - name: Save Playwright browsers cache
-        uses: actions/cache/save@v4
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+      # - name: Save Playwright browsers cache
+      #   uses: actions/cache/save@v4
+      #   if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      #   with:
+      #     path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+      #     key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -32,12 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
-      PLAYWRIGHT_BROWSERS_PATH: .playwright/browsers
       # Cache key prefixes for consistency. Note: Step IDs in `if` conditions below
       # are hardcoded (cache-node-modules-pnpm, cache-playwright-browsers) and cannot
       # be variables. Update these prefixes if you change cache naming strategy.
       CACHE_KEY_PREFIX_NODE_MODULES: cache-node-modules-pnpm
       CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS: cache-playwright-browsers
+
+      # Nuxt configuration - sourced from GitHub repository secrets
+      NUXT_PUBLIC_ADS_SERVER: ${{ secrets.NUXT_PUBLIC_ADS_SERVER }}
+      NUXT_PUBLIC_AD_CLIENT: ${{ secrets.NUXT_PUBLIC_AD_CLIENT }}
+
+      PLAYWRIGHT_BROWSERS_PATH: .playwright/browsers
     steps:
       # --- SHARED SETUP (Runs once per workflow) ---
 
@@ -94,8 +99,9 @@ jobs:
         run: pnpm test
 
       # Build once and reuse for E2E
-      - name: Build application
-        run: pnpm build
+      # Note: Not necessary as Playwright has command that starts the server
+      # - name: Build application
+      #   run: pnpm build
 
       # --- E2E PHASE (Reuses existing environment) ---
 
@@ -128,6 +134,8 @@ jobs:
       - name: Run E2E tests
         run: pnpm test:e2e
         env:
+          NUXT_PUBLIC_ADS_SERVER: ${{ secrets.NUXT_PUBLIC_ADS_SERVER }}
+          NUXT_PUBLIC_AD_CLIENT: ${{ secrets.NUXT_PUBLIC_AD_CLIENT }}
           PLAYWRIGHT_BROWSERS_PATH: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
       # --- ARTIFACT UPLOADS ---

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -57,7 +57,7 @@ jobs:
       # On cache hit this avoids running `pnpm install`; on cache miss
       # the subsequent steps will run `pnpm install` and populate the cache
       # for future workflow runs.
-      - name: Cache node_modules and .pnpm-store
+      - name: Restore node_modules and .pnpm-store cache
         id: cache-node-modules-pnpm
         uses: actions/cache@v4
         with:
@@ -96,7 +96,7 @@ jobs:
       # Uses the lockfile/hash to invalidate when dependencies (or Playwright)
       # change. On cache hit the install step is skipped.
       # Project-scoped to .playwright/browsers for consistency with node_modules.
-      - name: Cache Playwright browsers
+      - name: Restore Playwright browsers cache
         id: cache-playwright-browsers
         uses: actions/cache@v4
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -64,13 +64,22 @@ jobs:
           path: |
             node_modules
             .pnpm-store
-          key: ${{ runner.os }}-node-modules-pnpm-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          key: ${{ runner.os }}-cache-node-modules-pnpm-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-pnpm-
+            ${{ runner.os }}-cache-node-modules-pnpm-
 
       - name: Install dependencies
         if: steps.cache-node-modules-pnpm.outputs.cache-hit != 'true'
         run: pnpm install --no-frozen-lockfile
+
+      - name: Save node_modules and .pnpm-store cache
+        uses: actions/cache/save@v4
+        if: steps.cache-node-modules-pnpm.outputs.cache-hit != 'true'
+        with:
+          path: |
+            node_modules
+            .pnpm-store
+          key: ${{ runner.os }}-cache-node-modules-pnpm-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
 
       # --- VALIDATION PHASE ---
 
@@ -92,15 +101,22 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .playwright/browsers
-          key: ${{ runner.os }}-playwright-browsers-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          key: ${{ runner.os }}-cache-playwright-browsers-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-playwright-browsers-
+            ${{ runner.os }}-cache-playwright-browsers-
 
       - name: Install Playwright browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
         env:
           PLAYWRIGHT_BROWSERS_PATH: .playwright/browsers
+
+      - name: Save Playwright browsers cache
+        uses: actions/cache/save@v4
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        with:
+          path: .playwright/browsers
+          key: ${{ runner.os }}-cache-playwright-browsers-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,16 +17,23 @@ permissions:
   contents: read
   pull-requests: write
 
-# Concurrency control: Cancel in-progress runs when new commits are pushed
+# Concurrency: Cancel in-progress runs when new commits are pushed
 concurrency:
   group: pr-tests-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Unit Tests
+  # DESIGN PATTERN: Sequential Quality Check
+  # By combining Unit and E2E tests into a single job, we eliminate the need to
+  # re-run Checkout, Node setup, and pnpm install. This also allows us to use
+  # the build output directly without the overhead of uploading/downloading artifacts.
+  test-and-build:
+    name: Unit & E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
+      # --- SHARED SETUP (Runs once per workflow) ---
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -39,13 +46,45 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: 'pnpm'
+          # Enables built-in dependency caching for pnpm using pnpm-lock.yaml.
+          # This speeds up installs across workflow runs, but `pnpm install`
+          # is still required to link dependencies for the current job.
+          cache: pnpm
+
+      # Cache for pnpm is handled by setup-node (cache: pnpm), so no extra actions/cache needed.
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
+      # --- VALIDATION PHASE ---
+
       - name: Run unit tests
         run: pnpm test
 
+      # Build once and reuse for E2E
       - name: Build application
         run: pnpm build
+
+      # --- E2E PHASE (Reuses existing environment) ---
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
+      # --- ARTIFACT UPLOADS ---
+
+      - name: Upload build output
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: .output
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: playwright-results

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -53,19 +53,23 @@ jobs:
 
       # Cache for pnpm is handled by setup-node (cache: pnpm), so no extra actions/cache needed.
 
-      - name: Restore node_modules cache
-        id: node-mod-cache
+      # Restore cached node_modules and pnpm store when available.
+      # On cache hit this avoids running `pnpm install`; on cache miss
+      # the subsequent steps will run `pnpm install` and populate the cache
+      # for future workflow runs.
+      - name: Cache node_modules and .pnpm-store
+        id: cache-node-modules-pnpm
         uses: actions/cache@v4
         with:
           path: |
             node_modules
             .pnpm-store
-          key: ${{ runner.os }}-pnpm-node-modules-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          key: ${{ runner.os }}-node-modules-pnpm-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-node-modules-
+            ${{ runner.os }}-node-modules-pnpm-
 
       - name: Install dependencies
-        if: steps.node-mod-cache.outputs.cache-hit != 'true'
+        if: steps.cache-node-modules-pnpm.outputs.cache-hit != 'true'
         run: pnpm install --no-frozen-lockfile
 
       # --- VALIDATION PHASE ---
@@ -79,8 +83,24 @@ jobs:
 
       # --- E2E PHASE (Reuses existing environment) ---
 
+      # Cache Playwright downloaded browser binaries to speed up CI.
+      # Uses the lockfile/hash to invalidate when dependencies (or Playwright)
+      # change. On cache hit the install step is skipped.
+      # Project-scoped to .playwright/browsers for consistency with node_modules.
+      - name: Cache Playwright browsers
+        id: cache-playwright-browsers
+        uses: actions/cache@v4
+        with:
+          path: .playwright/browsers
+          key: ${{ runner.os }}-playwright-browsers-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-browsers-
+
       - name: Install Playwright browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: .playwright/browsers
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -31,6 +31,13 @@ jobs:
     name: Unit & E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: .playwright/browsers
+      # Cache key prefixes for consistency. Note: Step IDs in `if` conditions below
+      # are hardcoded (cache-node-modules-pnpm, cache-playwright-browsers) and cannot
+      # be variables. Update these prefixes if you change cache naming strategy.
+      CACHE_KEY_PREFIX_NODE_MODULES: cache-node-modules-pnpm
+      CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS: cache-playwright-browsers
     steps:
       # --- SHARED SETUP (Runs once per workflow) ---
 
@@ -64,9 +71,9 @@ jobs:
           path: |
             node_modules
             .pnpm-store
-          key: ${{ runner.os }}-cache-node-modules-pnpm-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-cache-node-modules-pnpm-
+            ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules-pnpm.outputs.cache-hit != 'true'
@@ -79,7 +86,7 @@ jobs:
           path: |
             node_modules
             .pnpm-store
-          key: ${{ runner.os }}-cache-node-modules-pnpm-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_NODE_MODULES }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
 
       # --- VALIDATION PHASE ---
 
@@ -100,26 +107,28 @@ jobs:
         id: cache-playwright-browsers
         uses: actions/cache@v4
         with:
-          path: .playwright/browsers
-          key: ${{ runner.os }}-cache-playwright-browsers-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-cache-playwright-browsers-
+            ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-
 
       - name: Install Playwright browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
         env:
-          PLAYWRIGHT_BROWSERS_PATH: .playwright/browsers
+          PLAYWRIGHT_BROWSERS_PATH: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
       - name: Save Playwright browsers cache
         uses: actions/cache/save@v4
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         with:
-          path: .playwright/browsers
-          key: ${{ runner.os }}-cache-playwright-browsers-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: ${{ runner.os }}-${{ env.CACHE_KEY_PREFIX_PLAYWRIGHT_BROWSERS }}-${{ hashFiles('**/pnpm-lock.yaml','**/package.json') }}
 
       - name: Run E2E tests
         run: pnpm test:e2e
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
       # --- ARTIFACT UPLOADS ---
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A Nuxt-based ad server that displays randomized advertisements from a backend AP
 
 **Security & Best Practices:**
 - **CORS Middleware** - Proper cross-origin request handling with configurable headers
+- **CORS Handling** - CORS is configured via hosting or static headers (server middleware removed from the repo)
 - **XSS Prevention** - Content sanitization and trusted origin validation
 - **Secret Management** - GitHub Secrets for sensitive credentials (never committed to repo)
 - **Access Control** - postMessage origin verification for iframe communication

--- a/TESTING.md
+++ b/TESTING.md
@@ -198,6 +198,7 @@ pnpm run test && pnpm test:e2e
 
 **ads.js Embed:**
 - ✅ No CORS errors
+- ⚠️ CORS handling depends on hosting/CDN configuration; server middleware was removed from the repository — ensure the deploy environment sets appropriate CORS headers to avoid embed failures
 
 ## Mock Data
 

--- a/docs/EXAMPLE_CLEAN_ARCHITECTURE.md
+++ b/docs/EXAMPLE_CLEAN_ARCHITECTURE.md
@@ -1,0 +1,36 @@
+## Example: Clean / Hexagonal Architecture in this repository
+
+This repo follows a clean (hexagonal) architecture: core domain logic is insulated from framework and I/O details by explicit ports (interfaces) and adapters (infrastructure).
+
+Layers and where to find them
+- **Domain (pure business rules):** validation and types live here. See [domain/ads/validators.ts](../domain/ads/validators.ts) and [domain/ads/types.ts](../domain/ads/types.ts). The `Result` pattern is in [domain/shared/result.ts](../domain/shared/result.ts).
+- **Application (use-cases + ports):** orchestrates flows and depends only on interfaces. See the `FetchRandomAd` use-case at [application/use-cases/FetchRandomAd.ts](../application/use-cases/FetchRandomAd.ts) and ports like [application/ports/IAdRepository.ts](../application/ports/IAdRepository.ts) and [application/ports/IConfigProvider.ts](../application/ports/IConfigProvider.ts).
+- **Infrastructure (adapters):** concrete implementations of ports and framework glue. Example: [infrastructure/repositories/AdRepository.ts](../infrastructure/repositories/AdRepository.ts) and [infrastructure/config/NuxtConfigProvider.ts](../infrastructure/config/NuxtConfigProvider.ts).
+- **Framework / UI:** components and composables that call use-cases, e.g. [components/RandomAd.vue](../components/RandomAd.vue) and [composables/useAdController.ts](../composables/useAdController.ts).
+
+How data flows (concise example)
+1. A caller (component or server route) asks the application for an ad by calling the use-case `FetchRandomAd` ([application/use-cases/FetchRandomAd.ts](../application/use-cases/FetchRandomAd.ts)).
+2. `FetchRandomAd` depends on the `IAdRepository` port ([application/ports/IAdRepository.ts](../application/ports/IAdRepository.ts)) and calls `fetchRandom()`.
+3. The concrete adapter `AdRepository` ([infrastructure/repositories/AdRepository.ts](../infrastructure/repositories/AdRepository.ts)) implements `IAdRepository`. It performs I/O (uses Nuxt's `$fetch`) and returns raw JSON.
+4. Before returning domain models, `AdRepository` converts raw JSON into domain objects by using the domain validators ([domain/ads/validators.ts](../domain/ads/validators.ts)). Those validators return a `Result` (`isOk` / `isErr`) defined in [domain/shared/result.ts](../domain/shared/result.ts).
+5. The use-case receives the `Result` and either forwards the domain object to the caller or propagates an error. Tests assert both success and failure scenarios.
+
+Why this is clean
+- Dependencies point inward: domain and application layers do not import Nuxt or `$fetch` — they only depend on interfaces. Concrete adapters live in `infrastructure`.
+- Easy to test: domain validators are pure and tested in [tests/unit/domain/validators.test.ts](../tests/unit/domain/validators.test.ts). Infrastructure adapters are tested by mocking the runtime `$fetch` as in [tests/unit/infrastructure/AdRepository.test.ts](../tests/unit/infrastructure/AdRepository.test.ts).
+- Small surface for change: to add a new ad type, implement a new validator in `domain/ads/validators.ts` and add tests; minimal changes to adapters or use-cases.
+
+Quick pointers (useful files)
+- Domain validators: [domain/ads/validators.ts](../domain/ads/validators.ts)
+- Use-case: [application/use-cases/FetchRandomAd.ts](../application/use-cases/FetchRandomAd.ts)
+- Ports: [application/ports/IAdRepository.ts](../application/ports/IAdRepository.ts), [application/ports/IConfigProvider.ts](../application/ports/IConfigProvider.ts)
+- Infrastructure adapter: [infrastructure/repositories/AdRepository.ts](../infrastructure/repositories/AdRepository.ts)
+- Unit tests (domain): [tests/unit/domain/validators.test.ts](../tests/unit/domain/validators.test.ts)
+- Unit tests (adapter): [tests/unit/infrastructure/AdRepository.test.ts](../tests/unit/infrastructure/AdRepository.test.ts)
+
+How to extend (example)
+1. Add a new ad shape: add parsing/validation logic to `domain/ads/validators.ts` and update domain `types.ts`.
+2. Add unit tests for the validator in `tests/unit/domain/`.
+3. If the API response changes, adapt `AdRepository` mapping in [infrastructure/repositories/AdRepository.ts](../infrastructure/repositories/AdRepository.ts) and update adapter tests.
+
+This structure keeps core business rules framework-agnostic, improves testability, and makes it straightforward to swap frameworks or run the code in different environments.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,10 +8,20 @@ const portTesting = 8810;
  */
 export default defineConfig({
   testDir: './tests/e2e',
+
+  // true: run tests in parallel (faster but may have race conditions)
+  // false: run sequentially (slower but more stable)
   fullyParallel: true,
+
+  // Prevent .only tests in CI to ensure full test suite runs
   forbidOnly: !!process.env.CI,
+
+  // Retry failed tests up to 2 times in CI for transient issues
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 4 : undefined,
+
+  // Limit to 4 workers in CI to reduce resource contention, otherwise use 1 worker for more stable test runs locally
+  workers: process.env.CI ? 4 : 1,
+
   reporter: [['html', { outputFolder: './playwright-results' }]],
   outputDir: './playwright-results',
   use: {
@@ -40,6 +50,6 @@ export default defineConfig({
     command: `pnpm dev --port=${portTesting}`,
     url: `http://localhost:${portTesting}`,
     reuseExistingServer: true,
-    timeout: 30 * 1000,
+    timeout: 120 * 1000,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 
   // true: run tests in parallel (faster but may have race conditions)
   // false: run sequentially (slower but more stable)
-  fullyParallel: true,
+  fullyParallel: false,
 
   // Prevent .only tests in CI to ensure full test suite runs
   forbidOnly: !!process.env.CI,
@@ -20,13 +20,15 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
 
   // Limit to 4 workers in CI to reduce resource contention, otherwise use 1 worker for more stable test runs locally
-  workers: process.env.CI ? 4 : 1,
+  workers: process.env.CI ? 2 : 1,
 
   reporter: [['html', { outputFolder: './playwright-results' }]],
   outputDir: './playwright-results',
   use: {
-    baseURL: 'http://localhost:8810',
+    baseURL: `http://localhost:${portTesting}`,
     trace: 'on-first-retry',
+    actionTimeout: 10000, // Individual actions shouldn't take forever
+    navigationTimeout: 15000, // Navigations can be a bit slower, especially on CI
   },
 
   projects: [
@@ -47,7 +49,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: `pnpm dev --port=${portTesting}`,
+    command: process.env.CI ? `pnpm build && pnpm preview --port=${portTesting}` : `pnpm dev --port=${portTesting}`,
     url: `http://localhost:${portTesting}`,
     reuseExistingServer: true,
     timeout: 120 * 1000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,8 +53,5 @@ export default defineConfig({
     url: `http://localhost:${portTesting}`,
     reuseExistingServer: true,
     timeout: 120 * 1000,
-    env: {
-      ...process.env,  // Inherit all parent env vars (including GitHub Actions secrets and variables)
-    },
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,5 +53,8 @@ export default defineConfig({
     url: `http://localhost:${portTesting}`,
     reuseExistingServer: true,
     timeout: 120 * 1000,
+    env: {
+      ...process.env,  // Inherit all parent env vars (including GitHub Actions secrets and variables)
+    },
   },
 });

--- a/project-audit.md
+++ b/project-audit.md
@@ -29,7 +29,7 @@ Date: 2026-02-03
 
 **Key modules/files**
 - Runtime config: [nuxt.config.ts](nuxt.config.ts)
-- CORS middleware: [server/middleware/cors-ivan.ts](server/middleware/cors-ivan.ts)
+- CORS handling: previously implemented via server middleware (server/middleware/cors-ivan.ts) — middleware folder removed; ensure hosting or CDN static headers provide appropriate CORS rules
 - API access currently embedded in UI: [components/RandomAd.vue](components/RandomAd.vue)
 
 **Boundary violations**
@@ -38,7 +38,7 @@ Date: 2026-02-03
 
 **High-risk couplings / failure points**
 - Missing or empty `NUXT_PUBLIC_ADS_SERVER` yields invalid requests with no fallback.
-- CORS middleware does not apply to static generation (noted in file), which may cause production mismatches.
+- Note: server middleware was removed and therefore CORS must be enforced by the hosting layer or static headers; verify CDN/host config to avoid production mismatches.
 - No retry, timeout, or error classification for ad server failures.
 
 ---

--- a/tests/e2e/critical-paths.spec.ts
+++ b/tests/e2e/critical-paths.spec.ts
@@ -24,6 +24,8 @@ async function gotoApp(page: Parameters<typeof test.beforeEach>[0]['page'], path
 }
 
 test.describe('Ad Server E2E Tests', () => {
+  // Run tests sequentially (one at a time) to avoid race conditions from parallel
+  // execution. Important for E2E tests that share a dev server instance.
   test.describe.configure({ mode: 'serial' });
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
Refactor `tests/e2e/critical-paths.spec.ts` to improve reliability and readability: add `gotoApp` helper, mock `/api/ads` with Playwright route/fulfill, and use `waitForResponse`/promises for deterministic assertions. Update `playwright.config.ts` (longer webServer timeout, stable local worker count).

Also add `docs/EXAMPLE_CLEAN_ARCHITECTURE.md`, clarify CORS handling in `README.md`, `TESTING.md`, and `project-audit.md`, and add the commit message prompt at `.github/prompts/commit-message.prompt.md`.

Improves E2E stability and repository documentation.